### PR TITLE
Add strict mapping annotations @BeanMapToClass / @BeanMapFromClass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper-spring-boot-starter</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 BeanMapper Spring Boot Starter</name>
     <description>Spring boot starter/autoconfig for BeanMapper</description>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper-spring</artifactId>
-            <version>0.1.8</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- TEST dependencies -->

--- a/src/main/java/io/beanmapper/autoconfigure/ApplicationScanner.java
+++ b/src/main/java/io/beanmapper/autoconfigure/ApplicationScanner.java
@@ -3,6 +3,8 @@ package io.beanmapper.autoconfigure;
 import static io.beanmapper.utils.Classes.forName;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -46,6 +48,20 @@ class ApplicationScanner {
         } catch (ClassNotFoundException | NoSuchElementException e) {
             log.error("Cannot find class annotated with SpringBootApplication. ", e);
             return Optional.empty();
+        }
+    }
+
+    Set<Class<?>> findBeanPairInstructions() {
+        Set<Class<?>> foundAnnotations = findBeanPairInstructions(BeanMapFromClass.class);
+        foundAnnotations.addAll(findBeanPairInstructions(BeanMapToClass.class));
+        return foundAnnotations;
+    }
+
+    private Set<Class<?>> findBeanPairInstructions(Class<? extends Annotation> markerAnnotation) {
+        try {
+            return entityScanner.scan(markerAnnotation);
+        } catch (ClassNotFoundException | NoSuchElementException e) {
+            return Collections.emptySet();
         }
     }
 

--- a/src/main/java/io/beanmapper/autoconfigure/BeanMapFromClass.java
+++ b/src/main/java/io/beanmapper/autoconfigure/BeanMapFromClass.java
@@ -1,0 +1,24 @@
+package io.beanmapper.autoconfigure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Sets the annotated class up as a strict target. The source class is the beneficiary. Both classes are
+ * registered with the BeanMapperBuilder with the target as strict. All properties in the target must
+ * have matching properties in the source. If matches are missing, an exception will be thrown at startup
+ * time, disrupting the boot process.
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BeanMapFromClass {
+
+    /**
+     * Source class and beneficiary of the target, ie the annotated class
+     */
+    Class<?> source();
+
+}

--- a/src/main/java/io/beanmapper/autoconfigure/BeanMapToClass.java
+++ b/src/main/java/io/beanmapper/autoconfigure/BeanMapToClass.java
@@ -1,0 +1,23 @@
+package io.beanmapper.autoconfigure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Sets the annotated class up as a strict source. The target class is the recipient. Both classes are
+ * registered with the BeanMapperBuilder with the source as strict. All properties in the source must
+ * have matching properties in the target. If matches are missing, an exception will be thrown at startup
+ * time, disrupting the boot process.
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BeanMapToClass {
+
+    /**
+     * Target class and recipient of the source, ie the annotated class
+     */
+    Class<?> target();
+
+}

--- a/src/main/java/io/beanmapper/autoconfigure/BeanMapperProperties.java
+++ b/src/main/java/io/beanmapper/autoconfigure/BeanMapperProperties.java
@@ -21,6 +21,12 @@ public class BeanMapperProperties {
      */
     private boolean useHibernateUnproxy = true;
 
+    private Boolean applyStrictMappingConvention = true;
+
+    private String strictSourceSuffix = "Form";
+
+    private String strictTargetSuffix = "Result";
+
     public boolean isUseHibernateUnproxy() {
         return useHibernateUnproxy;
     }
@@ -37,4 +43,27 @@ public class BeanMapperProperties {
         this.packagePrefix = basePackageName;
     }
 
+    public Boolean isApplyStrictMappingConvention() {
+        return applyStrictMappingConvention;
+    }
+
+    public void setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
+        this.applyStrictMappingConvention = applyStrictMappingConvention;
+    }
+
+    public String getStrictSourceSuffix() {
+        return strictSourceSuffix;
+    }
+
+    public void setStrictSourceSuffix(String strictSourceSuffix) {
+        this.strictSourceSuffix = strictSourceSuffix;
+    }
+
+    public String getStrictTargetSuffix() {
+        return strictTargetSuffix;
+    }
+
+    public void setStrictTargetSuffix(String strictTargetSuffix) {
+        this.strictTargetSuffix = strictTargetSuffix;
+    }
 }


### PR DESCRIPTION
Issue #2 Before the BeanMapper bean is initialized, all instances of BeanMapFromClass / BeanMapToClass are scanned. All class pair are registered with the annotation holder as strict. A strict class expects the other side to match all properties. If these are not matched, an exception is thrown during the boot process.