### PR TITLE
Make sure JpaAfterClearFlusher is registered if an EntityManager exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue [#83](https://github.com/42BV/beanmapper/issues/83), **The name field from an enum is not mapped to target field**; in the resolution of issue [#78](https://github.com/42BV/beanmapper/issues/78) the definition of getter fields has been tightened, because previously all private fields were tagged as available as well. One project made use of this loophole by reading the name field of an enumeration class to a String field. With the new fix this is no longer possible, since the name field is private. This fix makes an exception for the name field of an enum class. It will be considered available for reading.
+### Added
+- Issue [#6](https://github.com/42BV/beanmapper-spring-boot-starter/issues/6), **auto-register the JpaAfterClearFlusher**; when BeanMapper is in a JPA context, make sure the JpaAfterClearFlusher is registered with a valid EntityManager. This EM's flush can be called after a collection has been cleared. The result will be that the ORM is forced to execute its delete before its insert statement (the reverse of what would happen otherwise). Sample code:
+
+```
+@BeanCollection(elementType = ProjectSkill.class, flushAfterClear = true)
+public List<ProjectSkillForm> skills;
+```
+
+## [2.0.2] - 2017-10-18
+### Fixed
+- Issue [#21](https://github.com/42BV/beanmapper-spring/issues/21), **Multipart part name not used correctly**; the multipart part name was not handled correctly. Spring's multipart handler is now passed a MethodParameter which has the correct part name and also disables the parameter name explorer, so it is forced to used the overwritten part name.
 
 ## [2.0.1] - 2017-10-18
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this maven dependency to your project and you can start wiring the `BeanMapp
 <dependency>
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper-spring-boot-starter</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper-spring-boot-starter</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <packaging>jar</packaging>
     <name>42 BeanMapper Spring Boot Starter</name>
     <description>Spring boot starter/autoconfig for BeanMapper</description>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper-spring</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
         </dependency>
 
         <!-- TEST dependencies -->

--- a/src/test/java/io/beanmapper/autoconfigure/BeanMapperAutoConfigTest.java
+++ b/src/test/java/io/beanmapper/autoconfigure/BeanMapperAutoConfigTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.util.ReflectionTestUtils.getField;
 
 import java.util.List;
 
+import javax.persistence.EntityManager;
+
 import io.beanmapper.BeanMapper;
 import io.beanmapper.config.BeanMapperBuilder;
 import io.beanmapper.core.BeanFieldMatch;

--- a/src/test/java/io/beanmapper/autoconfigure/TestCollectionHandler.java
+++ b/src/test/java/io/beanmapper/autoconfigure/TestCollectionHandler.java
@@ -18,4 +18,9 @@ public class TestCollectionHandler extends AbstractCollectionHandler<TestEntity>
         return null;
     }
 
+    @Override
+    public int size(TestEntity targetCollection) {
+        return 0;
+    }
+
 }

--- a/src/test/java/io/beanmapper/autoconfigure/TestCollectionHandlerWithAppCtx.java
+++ b/src/test/java/io/beanmapper/autoconfigure/TestCollectionHandlerWithAppCtx.java
@@ -29,4 +29,9 @@ public class TestCollectionHandlerWithAppCtx extends AbstractCollectionHandler<T
     public TestEntity2 copy(BeanMapper beanMapper, Class collectionElementClass, TestEntity2 source, TestEntity2 target) {
         return null;
     }
+
+    @Override
+    public int size(TestEntity2 targetCollection) {
+        return 0;
+    }
 }


### PR DESCRIPTION
Issue #6 when JPA is in play, make sure to register the JpaAfterClearFlusher with a valid EntityManager. This will be added to the flush-chain, to be potentially executed when flushAfterClear is turned on. This can be either set on BeanCollection or the override configuration.

Note that @PersistenceContext cannot be used in the auto-configuration, since this will fail the tests. Instead optional @Autowired is used.