### PR TITLE
Feature/secured field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+This release effectively adds the following functionality:
+- **@BeanRoleSecured annotation**; checks the Principal for any one of the stated roles. If allowed, the mapping will proceed as normal. If not allowed, the mapping will not take place.
+- **@BeanLogicSecured annotation**; consults the stated class for the allowance check. The LogicSecuredCheck class will be instantiated by the starter. Its isAllowed() method will be called with the source and the target by BeanMapper. The types can be finetuned by setting the generics. Extending the class from AbstractSpringSecuredCheck gives access to the Principal and the ```hasRole()``` method. If allowed, the mapping will proceed as normal. If not allowed, the mapping will not take place.
+
 ### Added
-- Issue [#8](https://github.com/42BV/beanmapper-spring-boot-starter/issues/8), **Make sure BeanMapper bootstraps SecuredPropertyHandler**; when applySecuredProperties is set to true (in the YML), register SpringSecuredPropertyHandler, so that BeanMapper can properly deal with properties annotated with @BeanSecuredProperty.
-- Issue [#29](https://github.com/42BV/beanmapper-spring/issues/29); **Spring Security based implementation for @SecuredPropertyHandler** Added a Spring Security implementation for the @SecuredPropertyHandler. It will compare the Principal's authorities against the required authorities. At least one match will suffice to grant access.
-- Issue [#105](https://github.com/42BV/beanmapper/issues/105), **Ability to deal with @BeanSecuredProperty by delegating to a SecuredPropertyHandler**; when a field is tagged as @BeanSecuredProperty, BeanMapper will query its attached SecuredPropertyHandler. The handler will most likely be associated with a security implementation, such as Spring Security (not handled here). If no handler is present, access is granted by default.
+- Issue [#8](https://github.com/42BV/beanmapper-spring-boot-starter/issues/8), **Make sure BeanMapper bootstraps RoleSecuredCheck**; when applySecuredProperties is set to true (in the YML), register SpringRoleSecuredCheck, so that BeanMapper can properly deal with properties annotated with @BeanSecuredProperty.
+- Issue [#29](https://github.com/42BV/beanmapper-spring/issues/29); **Spring Security based implementation for @RoleSecuredCheck** Added a Spring Security implementation for the @RoleSecuredCheck. It will compare the Principal's authorities against the required authorities. At least one match will suffice to grant access.
+- Issue [#105](https://github.com/42BV/beanmapper/issues/105), **Ability to deal with @BeanSecuredProperty by delegating to a RoleSecuredCheck**; when a field is tagged as @BeanSecuredProperty, BeanMapper will query its attached RoleSecuredCheck. The handler will most likely be associated with a security implementation, such as Spring Security (not handled here). If no handler is present, access is granted by default.
+- Issue [#106](https://github.com/42BV/beanmapper/issues/106), **When a @BeanSecuredProperty is found without a RoleSecuredCheck being set, throw an exception**; the absence of a RoleSecuredCheck is by default a reason to throw an exception when @BeanSecuredProperty is used anywhere within the application. 
+- Issue [#107](https://github.com/42BV/beanmapper/issues/107), **Test for access by running against LogicSecuredCheck instance**; ability to add LogicSecuredCheck classes to BeanMapper's configuration. These classes can be called upon using the @BeanLogicSecured annotation. It allows for more complex interaction with the enveloping security system, such as not only checking against roles, but also comparing fields in the source or target against information known about the Principal.
 
 ## [2.3.1] - 2017-11-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Issue [#8](https://github.com/42BV/beanmapper-spring-boot-starter/issues/8), **Make sure BeanMapper bootstraps SecuredPropertyHandler**; when applySecuredProperties is set to true (in the YML), register SpringSecuredPropertyHandler, so that BeanMapper can properly deal with properties annotated with @BeanSecuredProperty.
+- Issue [#29](https://github.com/42BV/beanmapper-spring/issues/29); **Spring Security based implementation for @SecuredPropertyHandler** Added a Spring Security implementation for the @SecuredPropertyHandler. It will compare the Principal's authorities against the required authorities. At least one match will suffice to grant access.
+- Issue [#105](https://github.com/42BV/beanmapper/issues/105), **Ability to deal with @BeanSecuredProperty by delegating to a SecuredPropertyHandler**; when a field is tagged as @BeanSecuredProperty, BeanMapper will query its attached SecuredPropertyHandler. The handler will most likely be associated with a security implementation, such as Spring Security (not handled here). If no handler is present, access is granted by default.
 
 ## [2.3.1] - 2017-11-02
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper-spring-boot-starter</artifactId>
-    <version>2.3.2</version>
+    <version>2.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 BeanMapper Spring Boot Starter</name>
     <description>Spring boot starter/autoconfig for BeanMapper</description>
@@ -80,9 +80,20 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper-spring</artifactId>
-            <version>2.3.2</version>
+            <version>2.4.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.beanmapper</groupId>
+            <artifactId>beanmapper</artifactId>
+            <version>2.4.0-SNAPSHOT</version>
         </dependency>
 
         <!-- TEST dependencies -->

--- a/src/main/java/io/beanmapper/autoconfigure/ApplicationScanner.java
+++ b/src/main/java/io/beanmapper/autoconfigure/ApplicationScanner.java
@@ -10,6 +10,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 
+import io.beanmapper.annotations.LogicSecuredCheck;
 import io.beanmapper.core.collections.CollectionHandler;
 import io.beanmapper.core.converter.BeanConverter;
 import io.beanmapper.utils.Classes;
@@ -74,11 +75,16 @@ class ApplicationScanner {
         return findClasses(basePackage, CollectionHandler.class);
     }
 
+    Set<Class<? extends LogicSecuredCheck>> findLogicSecuredCheckClasses(String basePackage) {
+        return findClasses(basePackage, LogicSecuredCheck.class);
+    }
+
     private <T> Set<Class<? extends T>> findClasses(String basePackage, Class<T> lookForClass) {
         Set<Class<? extends T>> converterClasses = new HashSet<>();
         classpathScanner.addIncludeFilter(createTypeFilterForClass(lookForClass));
         classpathScanner.findCandidateComponents(basePackage).forEach(
                 bd -> converterClasses.add((Class<T>) forName(bd.getBeanClassName())));
+        classpathScanner.resetFilters(false);
         return converterClasses;
     }
 

--- a/src/main/java/io/beanmapper/autoconfigure/BeanMapperAutoConfig.java
+++ b/src/main/java/io/beanmapper/autoconfigure/BeanMapperAutoConfig.java
@@ -15,6 +15,7 @@ import io.beanmapper.core.collections.CollectionHandler;
 import io.beanmapper.core.converter.BeanConverter;
 import io.beanmapper.spring.converter.IdToEntityBeanConverter;
 import io.beanmapper.spring.flusher.JpaAfterClearFlusher;
+import io.beanmapper.spring.security.SpringSecuredPropertyHandler;
 import io.beanmapper.spring.unproxy.HibernateAwareBeanUnproxy;
 import io.beanmapper.spring.web.MergedFormMethodArgumentResolver;
 import io.beanmapper.spring.web.converter.StructuredJsonMessageConverter;
@@ -80,7 +81,7 @@ public class BeanMapperAutoConfig {
     public BeanMapper beanMapper() {
         String packagePrefix = determinePackagePrefix();
         BeanMapperBuilder builder = new BeanMapperBuilder()
-                .setApplyStrictMappingConvention(props.isApplyStrictMappingConvention())
+                .setApplyStrictMappingConvention(props.getApplyStrictMappingConvention())
                 .setStrictSourceSuffix(props.getStrictSourceSuffix())
                 .setStrictTargetSuffix(props.getStrictTargetSuffix())
                 .addPackagePrefix(packagePrefix)
@@ -89,9 +90,17 @@ public class BeanMapperAutoConfig {
         addCustomConverters(builder, packagePrefix);
         addCustomBeanPairs(builder);
         addAfterClearFlusher(builder);
+        setSecuredPropertyHandler(builder);
         setUnproxy(builder);
         customize(builder);
         return builder.build();
+    }
+
+    private void setSecuredPropertyHandler(BeanMapperBuilder builder) {
+        if (!props.getApplySecuredProperties()) {
+            return;
+        }
+        builder.setSecuredPropertyHandler(new SpringSecuredPropertyHandler());
     }
 
     private void addAfterClearFlusher(BeanMapperBuilder builder) {

--- a/src/main/java/io/beanmapper/autoconfigure/BeanMapperProperties.java
+++ b/src/main/java/io/beanmapper/autoconfigure/BeanMapperProperties.java
@@ -23,6 +23,8 @@ public class BeanMapperProperties {
 
     private Boolean applyStrictMappingConvention = true;
 
+    private Boolean applySecuredProperties = false;
+
     private String strictSourceSuffix = "Form";
 
     private String strictTargetSuffix = "Result";
@@ -43,12 +45,20 @@ public class BeanMapperProperties {
         this.packagePrefix = basePackageName;
     }
 
-    public Boolean isApplyStrictMappingConvention() {
+    public Boolean getApplyStrictMappingConvention() {
         return applyStrictMappingConvention;
     }
 
     public void setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
         this.applyStrictMappingConvention = applyStrictMappingConvention;
+    }
+
+    public Boolean getApplySecuredProperties() {
+        return applySecuredProperties;
+    }
+
+    public void setApplySecuredProperties(Boolean applySecuredProperties) {
+        this.applySecuredProperties = applySecuredProperties;
     }
 
     public String getStrictSourceSuffix() {

--- a/src/main/java/io/beanmapper/autoconfigure/BeanMapperProperties.java
+++ b/src/main/java/io/beanmapper/autoconfigure/BeanMapperProperties.java
@@ -23,7 +23,7 @@ public class BeanMapperProperties {
 
     private Boolean applyStrictMappingConvention = true;
 
-    private Boolean applySecuredProperties = false;
+    private Boolean applySecuredProperties = true;
 
     private String strictSourceSuffix = "Form";
 

--- a/src/test/java/io/beanmapper/autoconfigure/BeanMapperAutoConfigTest.java
+++ b/src/test/java/io/beanmapper/autoconfigure/BeanMapperAutoConfigTest.java
@@ -8,8 +8,6 @@ import static org.springframework.test.util.ReflectionTestUtils.getField;
 
 import java.util.List;
 
-import javax.persistence.EntityManager;
-
 import io.beanmapper.BeanMapper;
 import io.beanmapper.config.BeanMapperBuilder;
 import io.beanmapper.core.BeanFieldMatch;


### PR DESCRIPTION
This release effectively adds the following functionality:
- **@BeanRoleSecured annotation**; checks the Principal for any one of the stated roles. If allowed, the mapping will proceed as normal. If not allowed, the mapping will not take place.
- **@BeanLogicSecured annotation**; consults the stated class for the allowance check. The LogicSecuredCheck class will be instantiated by the starter. Its isAllowed() method will be called with the source and the target by BeanMapper. The types can be finetuned by setting the generics. Extending the class from AbstractSpringSecuredCheck gives access to the Principal and the ```hasRole()``` method. If allowed, the mapping will proceed as normal. If not allowed, the mapping will not take place.
