### PR TITLE
Made beanmapper-spring-boot-starter compatible with Spring Boot 2 and Spring Framework 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper-spring-boot-starter</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 BeanMapper Spring Boot Starter</name>
     <description>Spring boot starter/autoconfig for BeanMapper</description>
@@ -28,6 +28,7 @@
         <url>https://github.com/42BV/beanmapper-spring-boot-starter</url>
         <connection>scm:git://github.com/42BV/beanmapper-spring-boot-starter.git</connection>
         <developerConnection>scm:git:git@github.com:42BV/beanmapper-spring-boot-starter.git</developerConnection>
+        <tag>HEAD</tag>
     </scm>
     
     <developers>
@@ -60,7 +61,13 @@
         <maven.cobertura.version>2.5.2</maven.cobertura.version>
         <maven.javadoc.version>2.8</maven.javadoc.version>
         <maven.project.version>2.4</maven.project.version>
+        <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+        <maven.scm.provider.gitexe.version>1.9.2</maven.scm.provider.gitexe.version>
         <maven.site.plugin.version>3.3</maven.site.plugin.version>
+
+        <spring.boot.version>2.0.3.RELEASE</spring.boot.version>
+        <beanmapper.version>2.4.1</beanmapper.version>
+        <beanmapper.spring.version>2.4.1.SPRING5</beanmapper.spring.version>
     </properties>
     
     <dependencies>
@@ -91,12 +98,12 @@
         <dependency>
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper-spring</artifactId>
-            <version>2.4.1</version>
+            <version>${beanmapper.spring.version}</version>
         </dependency>
         <dependency>
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper</artifactId>
-            <version>2.4.1</version>
+            <version>${beanmapper.version}</version>
         </dependency>
 
         <!-- TEST dependencies -->
@@ -112,7 +119,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>1.5.2.RELEASE</version>
+                <version>${spring.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -145,6 +152,20 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven.release.plugin.version}</version>
+                <dependencies>
+                    <!-- Fixes release commit creation on systems which are not in English -->
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-provider-gitexe</artifactId>
+                        <version>${maven.scm.provider.gitexe.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/io/beanmapper/autoconfigure/BeanMapperAutoConfig.java
+++ b/src/main/java/io/beanmapper/autoconfigure/BeanMapperAutoConfig.java
@@ -29,7 +29,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;

--- a/src/test/java/io/beanmapper/autoconfigure/BeanMapperAutoConfigTest.java
+++ b/src/test/java/io/beanmapper/autoconfigure/BeanMapperAutoConfigTest.java
@@ -20,9 +20,9 @@ import io.beanmapper.spring.web.MergedFormMethodArgumentResolver;
 
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockServletContext;


### PR DESCRIPTION
Made beanmapper-spring-boot-starter compatible with Spring Boot 2 and Spring Framework 5:

- Updated dependencies
- Changed autoconfiguration imports (breaks backwards compatibility)
- Correct POM for releasing using maven-release-plugin