### PR TITLE
Removed direct dependency on Spring Security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper-spring-boot-starter</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 BeanMapper Spring Boot Starter</name>
     <description>Spring boot starter/autoconfig for BeanMapper</description>

--- a/src/test/java/io/beanmapper/autoconfigure/NoSpringSecurityClassLoader.java
+++ b/src/test/java/io/beanmapper/autoconfigure/NoSpringSecurityClassLoader.java
@@ -1,0 +1,17 @@
+package io.beanmapper.autoconfigure;
+
+/**
+ * Mocked ClassLoader which does not load the class used to detect if Spring Security is on the classpath.
+ * This way, we can test if BeanMapperAutoConfig correctly omits the security-related features in such cases.
+ */
+public class NoSpringSecurityClassLoader extends ClassLoader {
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        if (name != null && !name.equals("org.springframework.security.authentication.AuthenticationManager")) {
+            return super.loadClass(name);
+        }
+
+        throw new NoClassDefFoundError(name);
+    }
+}


### PR DESCRIPTION
The AuthenticationManager declared in BeanMapperAutoConfig.java caused
applications without Spring Security on their classpath to fail when
including the beanmapper-spring-boot-starter as dependency. Since the
usage of the Spring Security features of BeanMapper-spring is optional,
projects without Spring Security should still be supported in
beanmapper-spring-boot-starter. In such cases, the @BeanLogicSecured and
@BeanRoleSecured annotations are not processed

Fixes #10 