### PR TITLE
Allow auto-configuration of BeanMapper without Spring Data JPA

### DIFF
--- a/src/test/java/io/beanmapper/autoconfigure/NoOpEntityManager.java
+++ b/src/test/java/io/beanmapper/autoconfigure/NoOpEntityManager.java
@@ -1,0 +1,281 @@
+package io.beanmapper.autoconfigure;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.FlushModeType;
+import javax.persistence.LockModeType;
+import javax.persistence.Query;
+import javax.persistence.StoredProcedureQuery;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaDelete;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaUpdate;
+import javax.persistence.metamodel.Metamodel;
+
+/**
+ * No-op implementation of {@link EntityManager}.
+ * Used to test if the auto-config of BeanMapper enables Hibernate-related features when an EntityManager Bean is present in the ApplicationContext.
+ */
+public class NoOpEntityManager implements EntityManager {
+
+    @Override
+    public void persist(Object entity) {
+
+    }
+
+    @Override
+    public <T> T merge(T entity) {
+        return null;
+    }
+
+    @Override
+    public void remove(Object entity) {
+
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey) {
+        return null;
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey, Map<String, Object> properties) {
+        return null;
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey, LockModeType lockMode) {
+        return null;
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey, LockModeType lockMode, Map<String, Object> properties) {
+        return null;
+    }
+
+    @Override
+    public <T> T getReference(Class<T> entityClass, Object primaryKey) {
+        return null;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void setFlushMode(FlushModeType flushMode) {
+
+    }
+
+    @Override
+    public FlushModeType getFlushMode() {
+        return null;
+    }
+
+    @Override
+    public void lock(Object entity, LockModeType lockMode) {
+
+    }
+
+    @Override
+    public void lock(Object entity, LockModeType lockMode, Map<String, Object> properties) {
+
+    }
+
+    @Override
+    public void refresh(Object entity) {
+
+    }
+
+    @Override
+    public void refresh(Object entity, Map<String, Object> properties) {
+
+    }
+
+    @Override
+    public void refresh(Object entity, LockModeType lockMode) {
+
+    }
+
+    @Override
+    public void refresh(Object entity, LockModeType lockMode, Map<String, Object> properties) {
+
+    }
+
+    @Override
+    public void clear() {
+
+    }
+
+    @Override
+    public void detach(Object entity) {
+
+    }
+
+    @Override
+    public boolean contains(Object entity) {
+        return false;
+    }
+
+    @Override
+    public LockModeType getLockMode(Object entity) {
+        return null;
+    }
+
+    @Override
+    public void setProperty(String propertyName, Object value) {
+
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        return null;
+    }
+
+    @Override
+    public Query createQuery(String qlString) {
+        return null;
+    }
+
+    @Override
+    public <T> TypedQuery<T> createQuery(CriteriaQuery<T> criteriaQuery) {
+        return null;
+    }
+
+    @Override
+    public Query createQuery(CriteriaUpdate updateQuery) {
+        return null;
+    }
+
+    @Override
+    public Query createQuery(CriteriaDelete deleteQuery) {
+        return null;
+    }
+
+    @Override
+    public <T> TypedQuery<T> createQuery(String qlString, Class<T> resultClass) {
+        return null;
+    }
+
+    @Override
+    public Query createNamedQuery(String name) {
+        return null;
+    }
+
+    @Override
+    public <T> TypedQuery<T> createNamedQuery(String name, Class<T> resultClass) {
+        return null;
+    }
+
+    @Override
+    public Query createNativeQuery(String sqlString) {
+        return null;
+    }
+
+    @Override
+    public Query createNativeQuery(String sqlString, Class resultClass) {
+        return null;
+    }
+
+    @Override
+    public Query createNativeQuery(String sqlString, String resultSetMapping) {
+        return null;
+    }
+
+    @Override
+    public StoredProcedureQuery createNamedStoredProcedureQuery(String name) {
+        return null;
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String procedureName) {
+        return null;
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String procedureName, Class... resultClasses) {
+        return null;
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String procedureName, String... resultSetMappings) {
+        return null;
+    }
+
+    @Override
+    public void joinTransaction() {
+
+    }
+
+    @Override
+    public boolean isJoinedToTransaction() {
+        return false;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> cls) {
+        return null;
+    }
+
+    @Override
+    public Object getDelegate() {
+        return null;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public boolean isOpen() {
+        return false;
+    }
+
+    @Override
+    public EntityTransaction getTransaction() {
+        return null;
+    }
+
+    @Override
+    public EntityManagerFactory getEntityManagerFactory() {
+        return null;
+    }
+
+    @Override
+    public CriteriaBuilder getCriteriaBuilder() {
+        return null;
+    }
+
+    @Override
+    public Metamodel getMetamodel() {
+        return null;
+    }
+
+    @Override
+    public <T> EntityGraph<T> createEntityGraph(Class<T> rootType) {
+        return null;
+    }
+
+    @Override
+    public EntityGraph<?> createEntityGraph(String graphName) {
+        return null;
+    }
+
+    @Override
+    public EntityGraph<?> getEntityGraph(String graphName) {
+        return null;
+    }
+
+    @Override
+    public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass) {
+        return null;
+    }
+}

--- a/src/test/java/io/beanmapper/autoconfigure/NoSpringDataClassLoader.java
+++ b/src/test/java/io/beanmapper/autoconfigure/NoSpringDataClassLoader.java
@@ -1,0 +1,16 @@
+package io.beanmapper.autoconfigure;
+
+/**
+ * Mocked classLoader to simulate usage of beanmapper-spring-boot-starter without Spring Data JPA on the classpath.
+ */
+public class NoSpringDataClassLoader extends ClassLoader {
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        if (name != null && !name.equals("javax.persistence.EntityManager") && !name.equals("org.hibernate.proxy.HibernateProxy")) {
+            return super.loadClass(name);
+        }
+
+        throw new NoClassDefFoundError(name);
+    }
+}

--- a/src/test/java/io/beanmapper/autoconfigure/TestEntity.java
+++ b/src/test/java/io/beanmapper/autoconfigure/TestEntity.java
@@ -1,4 +1,4 @@
 package io.beanmapper.autoconfigure;
 
-public class TestEntity {
+class TestEntity {
 }

--- a/src/test/java/io/beanmapper/autoconfigure/TestEntity2.java
+++ b/src/test/java/io/beanmapper/autoconfigure/TestEntity2.java
@@ -1,4 +1,4 @@
 package io.beanmapper.autoconfigure;
 
-public class TestEntity2 {
+class TestEntity2 {
 }


### PR DESCRIPTION
You can now have beanmapper-spring-boot-starter configure a BeanMapper
instance without needing to have spring-boot-start-data-jpa on your
classpath.

However, most features of BeanMapper-spring will be disabled if Spring
Data is not present on your classpath. You should still be able to use
the base features of BeanMapper, though.

Fixes #1