### PR TITLE
Updated BeanMapper and BeanMapper-Spring dependencies to version 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Upgrades
+- Upgraded beanmapper(4.0.1), beanmapper-spring(4.0.1).
+### Fixed
+- BeanMapper v4.0.1 adds a new converter, as such, a few tests had to be updated to use the appropriate expected values.
+
+## [4.0.0] - 2022-09-15
+### Upgrades
 - Upgraded beanmapper(4.0.0), beanmapper-spring(4.0.0) and spring-boot(2.7.3) dependencies.
 
 ## [3.2.0] - 2020-12-16

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <spring.boot.version>2.7.3</spring.boot.version>
-        <beanmapper.version>4.0.0</beanmapper.version>
-        <beanmapper.spring.version>4.0.0</beanmapper.spring.version>
+        <beanmapper.version>4.0.1</beanmapper.version>
+        <beanmapper.spring.version>4.0.1</beanmapper.spring.version>
 
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <maven.scm.provider.gitexe.version>1.13.0</maven.scm.provider.gitexe.version>

--- a/src/test/java/io/beanmapper/autoconfigure/BeanMapperAutoConfigTest.java
+++ b/src/test/java/io/beanmapper/autoconfigure/BeanMapperAutoConfigTest.java
@@ -53,28 +53,28 @@ public class BeanMapperAutoConfigTest {
     @Test
     public void autoconfig_shouldCreateBeanMapper_ifNotExists() {
         loadApplicationContext();
-        assertBeanMapper(1, 16);
+        assertBeanMapper(1, 17);
         assertMergedFormArgResolver();
     }
 
     @Test
     public void autoconfig_shouldCreateCustomizedBeanMapper_ifNotExists() {
         loadApplicationContext(ConfigWithBeanMapperBuilderCustomizer.class);
-        assertBeanMapper(1, 17);
+        assertBeanMapper(1, 18);
         assertMergedFormArgResolver();
     }
 
     @Test
     public void autoconfig_shouldNotCreateBeanMapper_ifAlreadyExists() {
         loadApplicationContext(ConfigWithBeanMapper.class);
-        assertBeanMapper(0, 11, false);
+        assertBeanMapper(0, 12, false);
         assertMergedFormArgResolver();
     }
 
     @Test
     public void autoconfig_shouldCreateBeanMapper_withDefaultUnproxy_whenEnvIsSet() {
         loadApplicationContext(BEANMAPPER_USE_HIBERNATE_UNPROXY_PROP);
-        assertBeanMapper(1, 16, false);
+        assertBeanMapper(1, 17, false);
         assertMergedFormArgResolver();
     }
 


### PR DESCRIPTION
- BeanMapper 4.0.1 adds another converter. As such, a few tests had to be updated, to reflect the correct number of converters.