### PR TITLE
Prepare for release 5.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <spring.boot.version>3.2.1</spring.boot.version>
-        <beanmapper.spring.version>5.0.4</beanmapper.spring.version>
+        <beanmapper.spring.version>5.0.5</beanmapper.spring.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <maven.scm.provider.gitexe.version>1.13.0</maven.scm.provider.gitexe.version>
     </properties>
@@ -205,7 +205,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>0.8.12</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/io/beanmapper/autoconfigure/BeanMapperAutoConfig.java
+++ b/src/main/java/io/beanmapper/autoconfigure/BeanMapperAutoConfig.java
@@ -13,6 +13,7 @@ import io.beanmapper.spring.web.MergedFormMethodArgumentResolver;
 import io.beanmapper.spring.web.converter.StructuredJsonMessageConverter;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.PostConstruct;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanInstantiationException;
@@ -28,6 +29,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.util.ClassUtils;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -46,6 +48,7 @@ import static org.springframework.beans.BeanUtils.instantiateClass;
  * will be added to the Spring MVC context.
  */
 @Configuration
+@EnableAspectJAutoProxy
 @AutoConfigureAfter(WebMvcAutoConfiguration.class)
 @EnableConfigurationProperties(BeanMapperProperties.class)
 public class BeanMapperAutoConfig {
@@ -72,7 +75,7 @@ public class BeanMapperAutoConfig {
 
     /**
      * Creates a {@link BeanMapper} bean with spring-data-jpa defaults.
-     * If a {@link BeanMapperBuilderCustomizer} bean is found, uses this to 
+     * If a {@link BeanMapperBuilderCustomizer} bean is found, uses this to
      * customize the builder before the {@link BeanMapper} is build.
      * @return BeanMapper
      */
@@ -110,7 +113,11 @@ public class BeanMapperAutoConfig {
 
         setUnproxy(builder);
         customize(builder);
-        return builder.build();
+        BeanMapper beanMapper = builder.build();
+        if (props.getDiagnosticsDetailLevel().isEnabled()) {
+            beanMapper = beanMapper.wrap(props.getDiagnosticsDetailLevel()).build();
+        }
+        return beanMapper;
     }
 
     private void setSecuredChecks(BeanMapperBuilder builder, String packagePrefix) {

--- a/src/main/java/io/beanmapper/autoconfigure/BeanMapperProperties.java
+++ b/src/main/java/io/beanmapper/autoconfigure/BeanMapperProperties.java
@@ -1,5 +1,7 @@
 package io.beanmapper.autoconfigure;
 
+import io.beanmapper.utils.diagnostics.DiagnosticsDetailLevel;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -28,6 +30,8 @@ public class BeanMapperProperties {
     private String strictSourceSuffix = "Form";
 
     private String strictTargetSuffix = "Result";
+
+    private DiagnosticsDetailLevel diagnosticsLevel = DiagnosticsDetailLevel.DISABLED;
 
     public boolean isUseHibernateUnproxy() {
         return useHibernateUnproxy;
@@ -75,5 +79,13 @@ public class BeanMapperProperties {
 
     public void setStrictTargetSuffix(String strictTargetSuffix) {
         this.strictTargetSuffix = strictTargetSuffix;
+    }
+
+    public DiagnosticsDetailLevel getDiagnosticsDetailLevel() {
+        return diagnosticsLevel;
+    }
+
+    public void setDiagnosticsDetailLevel(DiagnosticsDetailLevel diagnosticsLevel) {
+        this.diagnosticsLevel = diagnosticsLevel;
     }
 }


### PR DESCRIPTION
- Updated BeanMapper to version 4.1.6
- Added diagnosticsLevel config property, allowing Diagnostics to be enabled globally.